### PR TITLE
Use correct engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "webpack-dev-server": "1.8.2"
   },
   "engines": {
-    "node" : ">=0.10.32"
+    "iojs": ">= 1.0.0",
+    "node": ">= 0.12.0"
   }
 }


### PR DESCRIPTION
Hello I found `Promise` be used in `createContainer.js` and `renderToString.js`. But lack of importing Promise-like module like `bluebird`.

I have one testing repo work as well in node v0.12 and iojs-1.0.0 but will fail in node v0.10.

I am not pretty sure adding bluebird in dependencies is a good idea, so I sent this PR just make engine verification be right.
