### PR TITLE
Support component names when they are created as ES6 classes

### DIFF
--- a/src/lib/createContainer.js
+++ b/src/lib/createContainer.js
@@ -14,7 +14,7 @@ module.exports = function (Component, options) {
 	options = arguments[1] || {};
 
 	var Container = React.createClass({
-		displayName: Component.displayName + "Container",
+		displayName: (Component.displayName || Component.name) + "Container",
 		propTypes: {
 			queryParams: React.PropTypes.object,
 			onQuery:     React.PropTypes.func,


### PR DESCRIPTION
When you declare components as ES6 classes, they do not have `displayName` inferred, at least not with [Babel](http://babeljs.io). However, they have a `name` attribute, as all classes do.

See [this Babel issue](https://github.com/babel/babel/issues/1331) for a discussion - one could augment Babel to generate `displayName` on a per-project basis, but I think the better forward-looking solution for react-transmit is to support `name`.
