### PR TITLE
Guard setState so that it is not called when the container is already unmounted

### DIFF
--- a/src/lib/createContainer.js
+++ b/src/lib/createContainer.js
@@ -104,7 +104,9 @@ module.exports = function (Component, options) {
 
 				promise.then(function (queryResults) {
 					try {
-						_this.setState(queryResults);
+						// See discussion at https://github.com/facebook/react/issues/2787
+						if (_this.isMounted())
+							_this.setState(queryResults);
 					}
 					catch (error) {
 						// Call to setState may fail if renderToString() was used.


### PR DESCRIPTION
This is done to silence a warning in React:

> Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component CalculatorContainer. This is a no-op.

See discussion at https://github.com/facebook/react/issues/2787

As this issue is unresolved and there is no final opinion from React devs, I think it's prudent to add a guard for the time being.
