### PR TITLE
Pass updated variables from nextProps to forceFetch

### DIFF
--- a/src/lib/createContainer.js
+++ b/src/lib/createContainer.js
@@ -180,7 +180,7 @@ module.exports = function (Component, options) {
 		 */
 		componentWillReceiveProps: function (nextProps) {
 			if (isRootContainer(Container)) {
-				this.forceFetch();
+				this.forceFetch(nextProps.variables);
 			}
 		},
 		/**


### PR DESCRIPTION
Here is a gist with environment for reproducing: https://gist.github.com/alexeyraspopov/7ac0d01dc7fdbecaab69

The problem is in `componentWillReceiveProps` that is actually make a new requests when props were changed but `forceFetch` doesn't receive these new props.
