### PR TITLE
Allow customization of props before creating the React element.

### DIFF
--- a/src/lib/renderToString.js
+++ b/src/lib/renderToString.js
@@ -24,6 +24,8 @@ module.exports = function (Component, props) {
 
 		overrideCreateElement(
 			function (originalCreateElement, type, props, children) {
+				if (myProps.customizeProps)
+					props = myProps.customizeProps(props);
 				var args = [].slice.call(arguments, 1);
 
 				if (isRootContainer(type)) {
@@ -50,6 +52,8 @@ module.exports = function (Component, props) {
 
 				overrideCreateElement(
 					function (originalCreateElement, type, props, children) {
+						if (myProps.customizeProps)
+							props = myProps.customizeProps(props);
 						var args = [].slice.call(arguments, 1);
 
 						if (isRootContainer(type) && fetchedFragments.length) {


### PR DESCRIPTION
I'm using alt.js in my application and I have to pass an instance of the stores to my components for each request, so the state don't get shared between requests.

http://alt.js.org/docs/altInstances/
