### PR TITLE
fix wrong order of fetchedFragments

### DIFF
--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -23,7 +23,7 @@ module.exports = function (Component, props, targetDOMNode, callback) {
 			var args = [].slice.call(arguments, 1);
 
 			if (isRootContainer(type) && fetchedFragments.length) {
-				assign(props, fetchedFragments.pop());
+				assign(props, fetchedFragments.shift());
 			}
 
 			return originalCreateElement.apply(null, args);

--- a/src/lib/renderToString.js
+++ b/src/lib/renderToString.js
@@ -53,7 +53,7 @@ module.exports = function (Component, props) {
 						var args = [].slice.call(arguments, 1);
 
 						if (isRootContainer(type) && fetchedFragments.length) {
-							assign(props, fetchedFragments.pop());
+							assign(props, fetchedFragments.shift());
 						}
 
 						return originalCreateElement.apply(null, args);


### PR DESCRIPTION
``` javascript
// entry
class ArticleTags extends React.Component{
  render(){
    return (
      <div>
       <A />
       <B />
      </div>
      )
  }
}

// Commponent A
export default Transmit.createContainer(A, {
  initialVariables: [],

  fragments: {
    dataA: () => {}
  }
});

// Commponent B
export default Transmit.createContainer(B, {
  initialVariables: [],

  fragments: {
    dataB: () => {}
  }
});
```

When I used the above code , something wired happen: A got dataB and B got dataA. Then I looked down the source code and found this bug. Please @RickWong  verify and merge.
