### PR TITLE
react-transmit-native install update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ Inspired by: [Building the Facebook Newsfeed with Relay](http://facebook.github.
 
 ## Installation
 
+
 ```bash
+	# For web or Node:
 	npm install react-transmit
+	
+	# For React Native version 0.25 or later:
+	npm install react-transmit
+	
+	# For React Native version 0.25 or before:
+	npm install react-transmit-native
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ Inspired by: [Building the Facebook Newsfeed with Relay](http://facebook.github.
 ## Installation
 
 ```bash
-	# For web or Node:
 	npm install react-transmit
-	
-	# For React Native:
-	npm install react-transmit-native
 ```
 
 ## Usage


### PR DESCRIPTION
Per #69 I researched this and can actually use `react-transmit` directly instead of `react-transmit-native` for all apps 0.25 or later.

I am not sure if anyone now is going to create a React Native app so old or just not upgrading, but I just added a note to readme distinguishing the difference.