### PR TITLE
Allow specifying the closing tag to insert after

### DIFF
--- a/src/lib/injectIntoMarkup.js
+++ b/src/lib/injectIntoMarkup.js
@@ -13,10 +13,12 @@ var asciiJSON = require('ascii-json');
  * @param {String} markup
  * @param {Object} data
  * @param {?Array} scripts
+ * @param {?String} insertAfterClosingTag
  */
-function injectIntoMarkup(markup, data, scripts) {
+function injectIntoMarkup(markup, data, scripts, insertAfterClosingTag = 'body') {
 	var escapedJson = asciiJSON.stringify(data).replace(/<\//g, '<\\/');
 	var injected = '<script>window.__reactTransmitPacket=' + escapedJson + '</script>';
+	var closingTag = '</' + insertAfterClosingTag + '>'
 
 	if (scripts) {
 		injected += scripts.map(function(script) {
@@ -24,8 +26,8 @@ function injectIntoMarkup(markup, data, scripts) {
 		}).join('');
 	}
 
-	if (markup.indexOf('</body>') > -1) {
-		return markup.replace('</body>', injected + '$&');
+	if (markup.indexOf(closingTag) > -1) {
+		return markup.replace(closingTag, injected + '$&');
 	} else {
 		return markup + injected;
 	}


### PR DESCRIPTION
At our company we had recently a problem with SSR invalidation.

The core of the problem was that `Transmit. injectIntoMarkup` sets the script at the very end of the body tag.

Since we have some tools in place to inject vendor.js and app.js in specific places of our application. The final result was that when our app.js was evaluated and executed the data hydratation from injectIntoMarkup was yet not evaluated and non-existing. Producing react to invalidate the SSR rendering and starting over.

We have placed a workaround on that for our use case. But I think that allowing users to specify if the script should be placed in body|head would be nice.

Following a similar spirit of what `HtmlWebpackPlugin` allows you to configure:

```
inject: true | 'head' | 'body' | false Inject all assets into the given template or templateContent - When passing true or 'body' all javascript resources will be placed at the bottom of the body element. 'head' will place the scripts in the head element.
```

what do you think about this?